### PR TITLE
Warn when leaving with unsaved changes. Fixes #11

### DIFF
--- a/simpla-admin.html
+++ b/simpla-admin.html
@@ -74,9 +74,15 @@ var UNSAVED_WARNING = 'You have unsaved changes, are you sure you want to leave?
  * @return {String}  Warning message (for browsers that support it)
  */
 function warnUnsaved(e) {
-  var dirtyBuffer = !!Simpla.getState('buffer');
+  var buffer = Simpla.getState('buffer'),
+      isDirty = void 0;
 
-  if (dirtyBuffer) {
+  // Feature checks to see if buffer state exists, then checks to see if dirty
+  isDirty = buffer && Object.keys(buffer).some(function (path) {
+    return buffer[path].modified;
+  });
+
+  if (isDirty) {
     e.returnValue = UNSAVED_WARNING;
     return UNSAVED_WARNING;
   }

--- a/src/behaviors/unsavedChanges.js
+++ b/src/behaviors/unsavedChanges.js
@@ -7,9 +7,13 @@ const UNSAVED_WARNING = 'You have unsaved changes, are you sure you want to leav
  * @return {String}  Warning message (for browsers that support it)
  */
 function warnUnsaved(e) {
-  let dirtyBuffer = !!Simpla.getState('buffer');
+  let buffer = Simpla.getState('buffer'),
+      isDirty;
 
-  if (dirtyBuffer) {
+  // Feature checks to see if buffer state exists, then checks to see if dirty
+  isDirty = buffer && Object.keys(buffer).some(path => buffer[path].modified);
+
+  if (isDirty) {
     e.returnValue = UNSAVED_WARNING;
     return UNSAVED_WARNING;
   }


### PR DESCRIPTION
Uses Simpla's buffer state to check if there are unsaved changes on the page, if so, alerts to the user when they're about to leave.